### PR TITLE
fix(ui): Aumenta o tamanho da janela de download da atualização

### DIFF
--- a/update_checker.py
+++ b/update_checker.py
@@ -78,7 +78,7 @@ class DownloadProgressWindow(tk.Toplevel):
     def __init__(self, parent):
         super().__init__(parent)
         self.title("Baixando Atualização...")
-        self.geometry("400x150")
+        self.geometry("500x200")
         self.transient(parent)
         self.grab_set()
         self.protocol("WM_DELETE_WINDOW", lambda: None) # Impede o fechamento


### PR DESCRIPTION
A janela de download da atualização estava com um tamanho de 400x150, o que fazia com que alguns elementos da interface, como ícones, não fossem exibidos corretamente. O tamanho da janela foi aumentado para 500x200 para garantir que todos os elementos sejam visíveis.