### PR TITLE
Disable automatic update check on startup

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -642,7 +642,7 @@ def main():
     root = ttkb.Window(themename="darkly")
 
     # Adiciona a verificação de atualização na inicialização
-    check_for_updates(root, APP_VERSION, on_startup=True)
+    #check_for_updates(root, APP_VERSION, on_startup=True)
 
     root.withdraw()  # Esconde a janela principal inicialmente
 


### PR DESCRIPTION
This commit disables the automatic update check that runs when the application starts. The user requested to remove this feature.

The change was made by commenting out the `check_for_updates` function call in the `main` function of `main_app.py`.